### PR TITLE
fix(mcp): update Parallel Search endpoint

### DIFF
--- a/src/runtime/mcp/providers/parallel.ts
+++ b/src/runtime/mcp/providers/parallel.ts
@@ -1,4 +1,4 @@
-const PARALLEL_SEARCH_MCP_URL = "https://search-mcp.parallel.ai/mcp";
+const PARALLEL_SEARCH_MCP_URL = "https://search.parallel.ai/mcp";
 const PARALLEL_TASK_MCP_URL = "https://task-mcp.parallel.ai/mcp";
 
 export const PARALLEL_SEARCH_TOOLS = ["web_search", "web_fetch"] as const;

--- a/tests/mcp/parallel-agent-args.test.ts
+++ b/tests/mcp/parallel-agent-args.test.ts
@@ -1,7 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { getAgentAdapter } from "../../src/runtime/agents.js";
+import { getParallelSearchMcpUrl, getParallelTaskMcpUrl } from "../../src/runtime/mcp/providers/parallel.js";
 import type { McpServerInfo } from "../../src/runtime/mcp/types.js";
+
+test("parallel MCP URLs use the current endpoints", () => {
+  assert.equal(getParallelSearchMcpUrl(), "https://search.parallel.ai/mcp");
+  assert.equal(getParallelTaskMcpUrl(), "https://task-mcp.parallel.ai/mcp");
+});
 
 test("codex MCP args include bearer_token_env_var for parallel servers", () => {
   const servers = new Map<string, McpServerInfo>([
@@ -10,7 +16,7 @@ test("codex MCP args include bearer_token_env_var for parallel servers", () => {
       {
         id: "parallel_search",
         transport: "http",
-        url: "https://search-mcp.parallel.ai/mcp",
+        url: "https://search.parallel.ai/mcp",
         headers: { Authorization: "Bearer test" },
         bearerTokenEnvVar: "TINTIN_MCP_BEARER_PARALLEL_SEARCH",
         bearerToken: "test",


### PR DESCRIPTION
Tintin's Parallel provider still points Search sessions at the old `search-mcp.parallel.ai` hostname. Parallel's current Search MCP endpoint is `https://search.parallel.ai/mcp`, so this updates the shared provider URL used by both local and cloud sessions.

## What changed

- Migrate only the Parallel Search MCP URL to the current endpoint.
- Add focused regression coverage for the Search and Task endpoint values.
- Keep the existing Task MCP URL and bearer API-key behavior unchanged.

## Validation

- `npm run build`
- `node --test dist/tests/mcp/parallel-agent-args.test.js`
- `npm run typecheck`
- Anonymous MCP initialization against the new Search endpoint returned HTTP 200.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.